### PR TITLE
Add Requirements file to install all dependencies at once

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ The pipeline for the project looks as follows:
 - In the **prediction stage**, a witheld set of images is passed to RNN and the RNN generates the sentence one word at a time. The results are evaluated with **BLEU score**. The code also includes utilities for visualizing the results in HTML.
 
 ## Dependencies
-**Python 2.7**, modern version of **numpy/scipy**, **perl** (if you want to do BLEU score evaluation), **argparse** module. Most of these are okay to install with **pip**. 
+**Python 2.7**, modern version of **numpy/scipy**, **perl** (if you want to do BLEU score evaluation), **argparse** module. Most of these are okay to install with **pip**. To install all dependencies at once, run the command `pip install -r requirements.txt`
 
 I only tested this code with Ubuntu 12.04, but I tried to make it as generic as possible (e.g. use of **os** module for file system interactions etc. So it might work on Windows and Mac relatively easily.)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scipy
+argparse


### PR DESCRIPTION
Pip has a nice feature where you can pass it a requirements.txt file in an argument, and it will install all of the dependencies in the file at once. I have added such a file to this repo. 